### PR TITLE
feat(#3): add NavLink to navigation bar - add end prop for active and pending logic states

### DIFF
--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { NavLink, Outlet } from 'react-router-dom';
 
 import './Layout.css';
 import { auth } from '../api/config.js';
@@ -33,15 +33,15 @@ export function Layout() {
 				</main>
 				<nav className="Nav">
 					<div className="Nav-container">
-						<a href="#" className="Nav-link">
+						<NavLink to="/" className="Nav-link" end>
 							Home
-						</a>
-						<a href="#" className="Nav-link">
+						</NavLink>
+						<NavLink to="/list" className="Nav-link" end>
 							List
-						</a>
-						<a href="#" className="Nav-link">
+						</NavLink>
+						<NavLink to="/manage-list" className="Nav-link" end>
 							Manage List
-						</a>
+						</NavLink>
 					</div>
 				</nav>
 			</div>


### PR DESCRIPTION
## Description
Implemented code replaces `a` tags with `NavLink` to add additional functionality. We also added an end prop. The end prop adjusts how the active and pending states work by making the NavLink active only if the URL exactly matches the end of the to path. If the URL is longer, it won't be marked as active.
Links were tested and behaved accordingly to [documentation](https://reactrouter.com/en/6.14.2/components/nav-link).

## Related Issue #3 

## Acceptance Criteria

-  The nav element is added to the Layout component

 

- Links to the "Home", "List", and "Add item" pages of the app are In the nav element

 

- The links all function as expected using the NavLink component from react-router-dom

## Type of Changes
`added feature` and `enhancement`

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

### After
![Screen Shot 2024-08-10 at 6 36 49 PM](https://github.com/user-attachments/assets/5c826b26-b378-4746-b017-2adc4ac9f6bc)

![Screen Shot 2024-08-10 at 6 56 40 PM](https://github.com/user-attachments/assets/70a3f201-fe88-45cd-a163-2d58c185b22a)

![Screen Shot 2024-08-10 at 6 57 32 PM](https://github.com/user-attachments/assets/525fcbfd-18c8-4dc2-ac55-87e10f0be3f6)

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
- Sign in using Google account.
- Navigate to Home page by clicking on `Home` link.
- Navigate to List page by clicking on `List` link.
- Navigate to Manage List page by clicking on `Manage List` link.
- Currently navigated link becomes bold when clicked on by implementing `end` prop.
- `Side note`: conditional rendering based on authentication will be addressed in new GH issue.

- Temporarily modified `.Nav-link.active` css color (red) to test end prop. Please see screenshot below:
![Screen Shot 2024-08-10 at 7 15 49 PM](https://github.com/user-attachments/assets/0d3a0da1-8412-4e3c-b232-4568f2b43c8c)
