### PR TITLE
Issue #10: Error messages for empty item and duplicate item

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,7 @@ export function App() {
 					/>
 					<Route
 						path="/manage-list"
-						element={<ManageList listPath={listPath} user={user} />}
+						element={<ManageList listPath={listPath} user={user} data={data} />}
 					/>
 				</Route>
 			</Routes>

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { addItem, shareList } from '../api/firebase';
 
-export function ManageList({ listPath, user }) {
+export function ManageList({ listPath, user, data }) {
 	const currentUserId = user?.uid;
-
+	// console.log("Data", {data})
 	const [itemName, setItemName] = useState('');
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 	const [message, setMessage] = useState('');
@@ -17,11 +17,34 @@ export function ManageList({ listPath, user }) {
 		duplicate: 'Item already exists!',
 	};
 
+	const normalizeString = (str) => str.toLowerCase().replace(/[^a-z0-9-]/g, '');
+
+	const normalizedData = useMemo(
+		() => data.map((item) => normalizeString(item.name)),
+		[data],
+	);
+
 	const handleSubmit = async (event) => {
 		event.preventDefault();
+
+		const normalizedItemName = normalizeString(itemName);
+
+		if (!normalizedItemName) {
+			setMessage('empty');
+			return;
+		}
+
+		const itemMatch = normalizedData.includes(normalizedItemName);
+
+		if (itemMatch) {
+			setMessage('duplicate');
+			return;
+		}
+
 		try {
 			await addItem(listPath, { itemName, daysUntilNextPurchase });
 			setMessage('added');
+			setItemName('');
 		} catch (error) {
 			setMessage('failed');
 		}

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -110,10 +110,16 @@ export function ManageList({ listPath, user, data }) {
 					</label>
 				</fieldset>
 				<br />
-				<button type="submit">Add Item</button>
+				<button type="submit" aria-label="Add item to your list">
+					Add Item
+				</button>
 			</form>
 			<br></br>
-			{message && <p>{messages[message] || ''}</p>}
+			{message && (
+				<p aria-live="assertive" role="alert">
+					{messages[message] || ''}
+				</p>
+			)}
 
 			<div>
 				<form onSubmit={handleShare}>

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -9,13 +9,21 @@ export function ManageList({ listPath, user }) {
 	const [message, setMessage] = useState('');
 	const [recipientEmail, setRecipientEmail] = useState('');
 
+	const messages = {
+		added: 'Your item was successfully added!',
+		failed:
+			"Your item wasn't added! There was an error saving the item. Please try again.",
+		empty: 'Please enter an item to add to your list.',
+		duplicate: 'Item already exists!',
+	};
+
 	const handleSubmit = async (event) => {
 		event.preventDefault();
 		try {
 			await addItem(listPath, { itemName, daysUntilNextPurchase });
-			setMessage('Item was successfully saved to the database.');
+			setMessage('added');
 		} catch (error) {
-			setMessage('There was an error saving the item to the database.');
+			setMessage('failed');
 		}
 		setItemName('');
 		setDaysUntilNextPurchase(7);
@@ -43,7 +51,7 @@ export function ManageList({ listPath, user }) {
 					id="itemName"
 					value={itemName}
 					onChange={(e) => setItemName(e.target.value)}
-					required
+					// required
 				/>
 				<fieldset>
 					<legend>How soon will you need to buy this item again?</legend>
@@ -79,7 +87,7 @@ export function ManageList({ listPath, user }) {
 				<button type="submit">Add Item</button>
 			</form>
 			<br></br>
-			{message && <p>{message}</p>}
+			{message && <p>{messages[message] || ''}</p>}
 
 			<div>
 				<form onSubmit={handleShare}>

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -3,7 +3,6 @@ import { addItem, shareList } from '../api/firebase';
 
 export function ManageList({ listPath, user, data }) {
 	const currentUserId = user?.uid;
-	// console.log("Data", {data})
 	const [itemName, setItemName] = useState('');
 	const [daysUntilNextPurchase, setDaysUntilNextPurchase] = useState(7);
 	const [message, setMessage] = useState('');
@@ -17,7 +16,8 @@ export function ManageList({ listPath, user, data }) {
 		duplicate: 'Item already exists!',
 	};
 
-	const normalizeString = (str) => str.toLowerCase().replace(/[^a-z0-9-]/g, '');
+	const normalizeString = (str) =>
+		str.toLowerCase().replace(/[^a-z0-9-]+/g, '');
 
 	const normalizedData = useMemo(
 		() => data.map((item) => normalizeString(item.name)),
@@ -27,7 +27,7 @@ export function ManageList({ listPath, user, data }) {
 	const handleSubmit = async (event) => {
 		event.preventDefault();
 
-		const normalizedItemName = normalizeString(itemName);
+		const normalizedItemName = normalizeString(itemName.trim());
 
 		if (!normalizedItemName) {
 			setMessage('empty');
@@ -42,14 +42,17 @@ export function ManageList({ listPath, user, data }) {
 		}
 
 		try {
-			await addItem(listPath, { itemName, daysUntilNextPurchase });
+			await addItem(listPath, {
+				itemName: normalizedItemName,
+				daysUntilNextPurchase,
+			});
 			setMessage('added');
 			setItemName('');
+			setDaysUntilNextPurchase(7);
 		} catch (error) {
+			console.error('Error adding item:', error);
 			setMessage('failed');
 		}
-		setItemName('');
-		setDaysUntilNextPurchase(7);
 	};
 
 	const handleShare = (event) => {


### PR DESCRIPTION
## Description

This PR introduces validation checks to prevent users from adding empty items or duplicate items to their list. 

- Added logic to show an error message when a user attempts to add an empty item to their list.
- Introduced a check that prevents users from adding items that already exist in their list, considering variations in casing and punctuation using RegExp.
- Original entered item names are saved in the database. 

## Related Issue

- Closes #10 

## Acceptance Criteria

- [x] Show an error message if the user tries to submit an empty item
- [x] Show an error message if the user tries to submit a new item that is identical to an existing name. For instance, if the list contains apples and the user adds apples.
- [x] Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains apples and the user adds aPples or apples, or a pples.
- [x] The user’s original input is saved in the database

## Type of Changes

`enhancement` and `accessibility`

## Updates

### Before

- **Not Applicable** 

<!-- If UI feature, take provide screenshots -->

### After
![image](https://github.com/user-attachments/assets/5e3e50e3-484f-4d1b-a1a4-2ce391a7a9b0)

![image](https://github.com/user-attachments/assets/55ec6500-b165-4366-8947-79564dfdf036)

![image](https://github.com/user-attachments/assets/872f7f88-8db7-4cd4-85cd-ed5bd8450bb9)

## Testing Steps / QA Criteria

1. Sign In using a Google account.
2. Navigate to `Manage List` page.
3. Click on the `Item Name` text and to test:
- `Add Item` with blank input and it displays "Please enter an item to add to your list."
- Add an identical item and it displays "Item already exists!"
- Add the item name with any punctuation and casing normalized and it displays an error message accordingly.

Note: Item names can include letters, numbers, and hyphens. 
